### PR TITLE
Fix panic in extendModel

### DIFF
--- a/src/minisat/solver/simp.rs
+++ b/src/minisat/solver/simp.rs
@@ -475,7 +475,11 @@ impl SimpSolver {
                 self.core.model[x.var().toIndex()] = LBool::new(!x.sign());
             }
 
-            i -= j;
+            if i > j {
+                i -= j;
+            } else {
+                i = 0;
+            }
         }
     }
 


### PR DESCRIPTION
When j somehow outgrow i in extendModel, we have an underflow and the loop stop condition doesn't work properly. This leads to a panic.

The root cause is i and j being signed in the original C++ code and
being usize in the Rust code.

The bug was triggered on 3bitadd_32.cnf from the problem set
http://www.cs.ubc.ca/~hoos/SATLIB/Benchmarks/SAT/Bejing/Bejing.tar.gz

(Found on http://www.cs.ubc.ca/~hoos/SATLIB/benchm.html)